### PR TITLE
Remove wrapper of mpcalc.moist_lapse after metpy 1.2.0 update

### DIFF
--- a/dparcel/environment.py
+++ b/dparcel/environment.py
@@ -18,7 +18,7 @@ from scipy.interpolate import interp1d
 from scipy.integrate import solve_ivp, simps
 from scipy.optimize import minimize_scalar
 
-from .thermo import equivalent_potential_temperature, wetbulb, moist_lapse
+from .thermo import equivalent_potential_temperature, wetbulb
 
 
 class Environment:
@@ -268,8 +268,7 @@ class Environment:
             # descent to the final level
             z_final = z_final*units.meter
             p_final = self.pressure(z_final)
-            t_final = moist_lapse(
-                p_final, t_initial, p_initial, method='integration')
+            t_final = mpcalc.moist_lapse(p_final, t_initial, p_initial)
             w_final = mpcalc.saturation_mixing_ratio(p_final, t_final)
             tv_final = mpcalc.virtual_temperature(t_final, w_final)
 
@@ -296,7 +295,7 @@ class Environment:
         return dcape.item(), dcin.item()
 
 
-def idealised_sounding(relative_humidity, info='', name=''):
+def idealised_sounding(relative_humidity):
     """
     Create an idealised sounding.
 
@@ -312,9 +311,6 @@ def idealised_sounding(relative_humidity, info='', name=''):
 
     Args:
         relative_humidity: Relative humidity above the boundary layer.
-        info: Information to store with the sounding, e.g. date
-            (optional)
-        name: Short name for the sounding, e.g. 'Sydney' (optional).
 
     Returns:
         Arrays of pressure, height, temperature and specific humidity

--- a/dparcel/parcel.py
+++ b/dparcel/parcel.py
@@ -12,7 +12,7 @@ from scipy.interpolate import interp1d
 from scipy.integrate import solve_ivp
 
 from .thermo import (descend, equilibrate, equivalent_potential_temperature,
-                     saturation_specific_humidity, moist_lapse, mix,
+                     saturation_specific_humidity, moist_lapse_dj, mix,
                      saturation_equivalent_potential_temperature)
 from .environment import Environment, idealised_sounding
 
@@ -115,7 +115,7 @@ class Parcel(Environment):
             sol_states.append(next_state)
 
         if height.size == 1:
-            return tuple([var.item() for var in sol_states[-1]])
+            return [var.item() for var in sol_states[-1]]
 
         t_sol = concatenate(
             [state[0] for state in sol_states]).m_as(units.celsius)
@@ -551,9 +551,8 @@ class FastParcel(Environment):
         # obtain a first guess for temperature using Davies-Jones (2008)
         pressure = self.pressure(height)
         initial_pressure = self.pressure(initial_height)
-        temperature = moist_lapse(
-            pressure, initial_temperature, initial_pressure,
-            method='fast', improve=False)
+        temperature = moist_lapse_dj(
+            pressure, initial_temperature, initial_pressure, improve=False)
 
         # solve using Newton's method
         for _ in range(improve):

--- a/tests/test_parcel.py
+++ b/tests/test_parcel.py
@@ -652,9 +652,6 @@ def test_fastparcel_properties_all_moist():
         z_init, t_initial, l_initial, theta_e, total_water)
     actual_t, actual_q, actual_l = sydneyfast.properties(
         height, z_init, t_initial, z_switch, t_switch, theta_e, total_water)
-    (actual_t_moist, actual_q_moist,
-     actual_l_moist) = sydneyfast._properties_moist(
-        height, z_init, t_initial, theta_e, total_water)
     truth_t = [283.6021255, 284.50188453, 284.26175698]*units.kelvin
     truth_q = [0.00829667, 0.00860362, 0.00939808]*units.dimensionless
     truth_l = [0.00167194, 0.00105108, 0.]*units.dimensionless

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -7,7 +7,7 @@ from metpy.testing import assert_almost_equal, assert_array_equal
 from metpy.units import units
 
 from dparcel.thermo import (
-    moist_lapse,
+    moist_lapse_dj,
     temperature_change,
     saturation_specific_humidity,
     equivalent_potential_temperature,
@@ -23,64 +23,31 @@ from dparcel.thermo import (
     equilibrate,
 )
 
-def test_moist_lapse_scalar():
-    """Test moist_lapse for a single final pressure."""
-    actual = moist_lapse(1000*units.mbar, 0*units.celsius, 900*units.mbar)
-    truth = 5.140677691654389*units.celsius
-    assert_almost_equal(actual, truth, 3)
-    assert not hasattr(actual, 'size')
-
-def test_moist_lapse_up():
-    """Test moist_lapse for a decreasing pressure array."""
-    pressure = [900, 800, 700]*units.mbar
-    actual = moist_lapse(pressure, 0*units.celsius, 1000*units.mbar)
-    truth = [
-        -5.603133863724906, -12.223376120570379, -20.15342938802408,
-    ]*units.celsius
-    assert_almost_equal(actual, truth, 3)
-
-def test_moist_lapse_down():
-    """Test moist_lapse for an increasing pressure array."""
-    pressure = [800, 900, 1000]*units.mbar
-    actual = moist_lapse(pressure, -20*units.celsius, 700*units.mbar)
-    truth = [
-        -12.08128253224288, -5.472554931170237, 0.12013477440223141,
-    ]*units.celsius
-    assert_almost_equal(actual, truth, 3)
-
-def test_moist_lapse_no_reference():
-    """Test moist_lapse without a reference pressure supplied."""
-    pressure = [800, 900, 1000]*units.mbar
-    actual = moist_lapse(pressure, -20*units.celsius)
-    truth = [
-        -20.0, -12.835349000048097, -6.699583983263153,
-    ]*units.celsius
-    assert_almost_equal(actual, truth, 3)
-
-def moist_lapse_fast():
+def test_moist_lapse_dj():
     """Test the Davies-Jones pseudoadiabat calculation."""
     pressure = [800, 900, 1000]*units.mbar
-    actual = moist_lapse(
-        pressure, -20*units.celsius, 700*units.mbar, method='fast')
+    actual = moist_lapse_dj(pressure, -20*units.celsius, 700*units.mbar)
     truth = [
         -12.127397603992893, -5.541946232250285, 0.048623197584600486,
     ]*units.celsius
     assert_almost_equal(actual, truth, 3)
 
-def test_moist_lapse_fast_no_reference():
+def test_moist_lapse_dj_no_reference():
     """Test the Davies-Jones calculation without a reference pressure."""
     pressure = [800, 900, 1000]*units.mbar
-    actual = moist_lapse(pressure, -20*units.celsius, method='fast')
+    actual = moist_lapse_dj(pressure, -20*units.celsius)
     truth = [
         -20.000637807046292, -12.873778773870667, -6.760509849394381,
     ]*units.celsius
     assert_almost_equal(actual, truth, 3)
 
-def test_moist_lapse_invalid_method():
-    """Check that moist_lapse raises an error if the method is invalid."""
-    with pytest.raises(ValueError):
-        _ = moist_lapse(
-            800*units.mbar, 0*units.celsius, 1000*units.mbar, method='hello')
+def test_moist_lapse_dj_scalar():
+    """Test the Davies-Jones calculation for scalar input."""
+    pressure = 800*units.mbar
+    actual = moist_lapse_dj(pressure, -20*units.celsius, 700*units.mbar)
+    truth = -12.127397603992893*units.celsius
+    assert_almost_equal(actual, truth, 3)
+    assert not hasattr(actual, 'size')
 
 def test_temperature_change():
     """Test temperature_change."""
@@ -355,7 +322,7 @@ def test_descend_dry():
     assert not hasattr(actual_l, 'size')
 
 
-def test_descent_moist_pseudoadiabatic():
+def test_descend_moist_pseudoadiabatic():
     """Test descend for moist pseudoadiabatic descent."""
     actual_t, actual_q, actual_l = descend(
         600*units.mbar, -20*units.celsius,
@@ -371,7 +338,7 @@ def test_descent_moist_pseudoadiabatic():
     assert not hasattr(actual_q, 'size')
     assert not hasattr(actual_l, 'size')
 
-def test_descent_moist_reversible():
+def test_descend_moist_reversible():
     """Test descend for moist reversible adiabatic descent."""
     actual_t, actual_q, actual_l = descend(
         600*units.mbar, -20*units.celsius,
@@ -387,7 +354,7 @@ def test_descent_moist_reversible():
     assert not hasattr(actual_q, 'size')
     assert not hasattr(actual_l, 'size')
 
-def test_descent_mixed_pseudoadiabatic():
+def test_descend_mixed_pseudoadiabatic():
     """Test descend for mixed moist pseudoadiabatic and dry descent."""
     actual_t, actual_q, actual_l = descend(
         800*units.mbar, -20*units.celsius,
@@ -403,7 +370,7 @@ def test_descent_mixed_pseudoadiabatic():
     assert not hasattr(actual_q, 'size')
     assert not hasattr(actual_l, 'size')
 
-def test_descent_mixed_reversible():
+def test_descend_mixed_reversible():
     """Test descend for mixed moist reversible adiabatic and dry descent."""
     actual_t, actual_q, actual_l = descend(
         800*units.mbar, -20*units.celsius,


### PR DESCRIPTION
Metpy 1.2.0 was just released with a fix for the moist_lapse bug.